### PR TITLE
Update Philadox URL

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1647,7 +1647,7 @@ mapboard({
                     {
                       label: 'ID',
                       value: function (state, item) {
-                        return "<a target='_blank' href='//pdx-app01/recorder/eagleweb/viewDoc.jsp?node=DOCC"+item.attributes.R_NUM+"'>"+item.attributes.R_NUM+"<i class='fa fa-external-link'></i></a>"
+                        return "<a target='_blank' href='http://pdx-app01.city.phila.local/recorder/eagleweb/viewDoc.jsp?node=DOCC"+item.attributes.R_NUM+"'>"+item.attributes.R_NUM+"<i class='fa fa-external-link'></i></a>"
                       },
                     },
                     {


### PR DESCRIPTION
This makes the link work on macOS (which for some reason can't resolve `pdx-app01` => `pdx-app01.city.phila.local`).